### PR TITLE
Add simple RL agent skeleton and usage instructions

### DIFF
--- a/RocketLeagueRLBot/README.md
+++ b/RocketLeagueRLBot/README.md
@@ -19,19 +19,34 @@ Ten projekt ma na celu stworzenie bota opartego na sztucznej inteligencji (AI), 
 
 ## Wymagania Wstępne
 
-(Zostanie uzupełnione później)
+- Python 3.8 lub nowszy
+- Zainstalowana gra **Rocket League**
+- Biblioteka `rlgym` umożliwiająca komunikację gry z Pythonem
 
 ## Instalacja
 
-(Zostanie uzupełnione później)
+1. Sklonuj repozytorium i przejdź do katalogu `RocketLeagueRLBot`.
+2. Zainstaluj zależności komendą:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
 
 ## Użycie
 
-(Zostanie uzupełnione później)
+1. Uruchom Rocket League w trybie treningu.
+2. Następnie w terminalu wykonaj:
+
+   ```bash
+   python -m src.main
+   ```
 
 ## Trening Bota
 
-(Zostanie uzupełnione później)
+Parametry treningu znajdują się w pliku `config/settings.json` w sekcji
+`training_params`. Domyślnie bot trenuje przez 10 epizodów. Możesz zmienić tę
+wartość na dowolną liczbę. Po uruchomieniu skryptu `python -m src.main` bot
+rozpocznie prostą sesję treningową w przygotowanym środowisku.
 
 ## TODO
 

--- a/RocketLeagueRLBot/config/settings.json
+++ b/RocketLeagueRLBot/config/settings.json
@@ -8,5 +8,12 @@
   "agent_params": {
     "learning_rate": 0.001,
     "discount_factor": 0.99
+  },
+  "training_params": {
+    "num_episodes": 10
+  },
+  "env_params": {
+    "observation_space": 10,
+    "action_space": 5
   }
-} 
+}

--- a/RocketLeagueRLBot/requirements.txt
+++ b/RocketLeagueRLBot/requirements.txt
@@ -1,5 +1,3 @@
-# Ten plik będzie zawierał listę zależności projektu Python.
-# Przykładowo:
-# tensorflow
-# numpy
-# rlgym 
+torch
+numpy
+rlgym

--- a/RocketLeagueRLBot/src/agent/model.py
+++ b/RocketLeagueRLBot/src/agent/model.py
@@ -2,16 +2,32 @@
 # Może to być np. sieć konwolucyjna (CNN) do analizy obrazu z gry
 # lub sieć rekurencyjna (RNN) do przetwarzania sekwencji stanów.
 
-class AgentModel:
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class AgentModel(nn.Module):
+    """Prosty model sieci neuronowej używany przez agenta."""
+
     def __init__(self, observation_space, action_space):
+        super().__init__()
         self.observation_space = observation_space
         self.action_space = action_space
-        # TODO: Zdefiniuj architekturę sieci neuronowej
+        # Minimalna sieć w pełni połączona
+        self.fc1 = nn.Linear(observation_space, 128)
+        self.fc2 = nn.Linear(128, action_space)
         print("Model agenta zainicjalizowany.")
 
+    def forward(self, x):
+        x = F.relu(self.fc1(x))
+        return self.fc2(x)
+
     def predict(self, state):
-        # TODO: Implementacja predykcji akcji na podstawie stanu
-        print(f"Predykcja dla stanu: {state}")
-        # Na razie zwracamy losową akcję
-        import random
-        return random.choice(range(self.action_space)) 
+        """Zwraca akcję na podstawie aktualnego stanu."""
+        if not isinstance(state, torch.Tensor):
+            state = torch.tensor(state, dtype=torch.float32)
+        with torch.no_grad():
+            logits = self.forward(state)
+            action = torch.argmax(logits).item()
+        return action

--- a/RocketLeagueRLBot/src/agent/trainer.py
+++ b/RocketLeagueRLBot/src/agent/trainer.py
@@ -10,12 +10,13 @@ class AgentTrainer:
 
     def train(self, num_episodes):
         print(f"Rozpoczynam trening na {num_episodes} epizodów.")
-        # TODO: Implementacja pętli treningowej
         for episode in range(num_episodes):
-            # Logika pojedynczego epizodu treningowego
             print(f"Epizod {episode + 1}/{num_episodes}")
-            # Zresetuj środowisko
-            # Wykonuj akcje, obserwuj stany i nagrody
-            # Aktualizuj model
-            pass
-        print("Trening zakończony.") 
+            state = self.environment.reset()
+            done = False
+            while not done:
+                action = self.agent_model.predict(state)
+                next_state, reward, done, _ = self.environment.step(action)
+                # TODO: tutaj należałoby zaimplementować aktualizację modelu
+                state = next_state
+        print("Trening zakończony.")

--- a/RocketLeagueRLBot/src/env/rl_environment.py
+++ b/RocketLeagueRLBot/src/env/rl_environment.py
@@ -1,36 +1,44 @@
 # Ten plik będzie zawierał definicję środowiska Rocket League,
 # zgodnego z interfejsem typowym dla bibliotek reinforcement learning (np. OpenAI Gym).
 
+import random
+
+
 class RocketLeagueEnv:
+    """Proste środowisko demonstracyjne dla bota Rocket League."""
+
     def __init__(self, config):
-        self.config = config
-        # TODO: Inicjalizacja połączenia z grą Rocket League
-        # np. przy użyciu rlgym lub innego API
+        self.config = config or {}
+        # W prawdziwym projekcie tutaj należałoby zainicjalizować połączenie z
+        # grą Rocket League przy użyciu np. biblioteki rlgym.
         print("Środowisko Rocket League zainicjalizowane.")
-        self.observation_space = None # Zdefiniuj przestrzeń obserwacji
-        self.action_space = None    # Zdefiniuj przestrzeń akcji
+        self.observation_space = self.config.get("env_params", {}).get(
+            "observation_space", 10
+        )
+        self.action_space = self.config.get("env_params", {}).get(
+            "action_space", 5
+        )
 
     def reset(self):
-        # TODO: Zresetuj stan gry do początkowego
+        """Resetuje środowisko i zwraca początkowy stan."""
         print("Resetowanie środowiska.")
-        initial_state = None # Pobierz początkowy stan
+        # W prawdziwej implementacji zwrócony zostałby stan gry po restarcie.
+        initial_state = [0.0 for _ in range(self.observation_space)]
         return initial_state
 
     def step(self, action):
-        # TODO: Wykonaj akcję w grze i zwróć nowy stan, nagrodę, flagę zakończenia epizodu i dodatkowe informacje
+        """Wykonuje akcję i zwraca rezultaty."""
         print(f"Wykonywanie akcji: {action}")
-        next_state = None
-        reward = 0
-        done = False
+        next_state = [random.random() for _ in range(self.observation_space)]
+        reward = random.random()
+        done = random.random() < 0.1
         info = {}
         return next_state, reward, done, info
 
     def render(self, mode='human'):
-        # TODO: Opcjonalnie, renderuj stan gry (jeśli to potrzebne i możliwe)
+        """Opcjonalne renderowanie stanu gry."""
         print(f"Renderowanie środowiska (tryb: {mode})")
-        pass
 
     def close(self):
-        # TODO: Zamknij połączenie z grą i zwolnij zasoby
+        """Zamyka środowisko i zwalnia zasoby."""
         print("Zamykanie środowiska Rocket League.")
-        pass 

--- a/RocketLeagueRLBot/src/main.py
+++ b/RocketLeagueRLBot/src/main.py
@@ -1,7 +1,20 @@
+from src.utils.helpers import load_config
+from src.agent.model import AgentModel
+from src.agent.trainer import AgentTrainer
+from src.env.rl_environment import RocketLeagueEnv
+
+
 def main():
     print("Witaj w RocketLeagueRLBot!")
-    # Tutaj będzie główna logika bota
-    # np. ładowanie konfiguracji, inicjalizacja agenta, start pętli treningowej/gry
+    config = load_config()
+    env = RocketLeagueEnv(config)
+    obs_space = env.observation_space
+    act_space = env.action_space
+    agent = AgentModel(obs_space, act_space)
+    trainer = AgentTrainer(agent, env, config)
+    num_episodes = config.get("training_params", {}).get("num_episodes", 10)
+    trainer.train(num_episodes)
 
 if __name__ == "__main__":
-    main() 
+    main()
+


### PR DESCRIPTION
## Summary
- implement dummy environment, trainer loop, and PyTorch model
- expand config with training and env params
- provide install and usage steps in README
- update requirements with torch, numpy, rlgym
- wire up new main script to load config and start training

## Testing
- `pytest -q`
- `python -m src.main | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_683f32b22afc8332933220aab6557c10