### PR TITLE
Add RLBot injector module

### DIFF
--- a/RocketLeagueRLBot/README.md
+++ b/RocketLeagueRLBot/README.md
@@ -27,7 +27,16 @@ Ten projekt ma na celu stworzenie bota opartego na sztucznej inteligencji (AI), 
 
 ## Użycie
 
-(Zostanie uzupełnione później)
+Możesz uruchomić mecz offline używając RLBot i pliku konfiguracyjnego
+`rlbot.cfg`. Przykładowo:
+
+```bash
+python -m src.env.rlbot_injector path/to/rlbot.cfg
+```
+
+Skrypt `rlbot_injector.py` wykorzystuje bibliotekę RLBot do
+uruchomienia gry i wstrzyknięcia bota zgodnie z ustawieniami w pliku
+konfiguracyjnym.
 
 ## Trening Bota
 

--- a/RocketLeagueRLBot/requirements.txt
+++ b/RocketLeagueRLBot/requirements.txt
@@ -2,4 +2,6 @@
 # Przykładowo:
 # tensorflow
 # numpy
-# rlgym 
+# rlgym
+rlbot
+

--- a/RocketLeagueRLBot/src/env/rlbot_injector.py
+++ b/RocketLeagueRLBot/src/env/rlbot_injector.py
@@ -1,0 +1,35 @@
+"""Simple injector that connects the RLBot framework with Rocket League.
+
+This module uses RLBot's `SetupManager` to launch the game and inject
+an agent for offline training. It expects an `rlbot.cfg` configuration
+file describing the match and bot to run.
+"""
+
+from pathlib import Path
+
+from rlbot.setup_manager import SetupManager
+
+
+def launch_offline_match(config_path: str) -> None:
+    """Launch Rocket League for offline training using RLBot.
+
+    Parameters
+    ----------
+    config_path: str
+        Path to the ``rlbot.cfg`` configuration file.
+    """
+    manager = SetupManager()
+    manager.load_config(Path(config_path))
+    manager.connect_to_game()
+    manager.launch_ball_prediction()
+    manager.launch_bot_processes()
+    manager.start_match()
+    manager.infinite_loop()
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) < 2:
+        print("Usage: python -m src.env.rlbot_injector <path_to_rlbot.cfg>")
+        sys.exit(1)
+    launch_offline_match(sys.argv[1])


### PR DESCRIPTION
## Summary
- create `rlbot_injector` to launch RLBot framework
- document how to use the injector
- list rlbot dependency in requirements

## Testing
- `python -m py_compile src/env/rlbot_injector.py`
- `python -m src.env.rlbot_injector` *(fails: ModuleNotFoundError: No module named 'imp')*

------
https://chatgpt.com/codex/tasks/task_e_683f3e58da808332b957acd908fc1bcd